### PR TITLE
Fix illustrator transition bug on yLinear

### DIFF
--- a/build/g-axis.js
+++ b/build/g-axis.js
@@ -456,7 +456,7 @@
 
             if (align === 'right') {
                 yLabel.selectAll('text')
-                .attr('dx', labelWidth);
+                .attr('transform', `translate(${(labelWidth)},0)`);
             }
 
             yLabel.selectAll('.tick')

--- a/src/yLinear.js
+++ b/src/yLinear.js
@@ -45,7 +45,7 @@ export default function () {
 
         if (align === 'right') {
             yLabel.selectAll('text')
-            .attr('dx', labelWidth);
+            .attr('transform', `translate(${(labelWidth)},0)`);
         }
 
         yLabel.selectAll('.tick')


### PR DESCRIPTION
Us transform to move the axis labels instead of dx