### PR TITLE
Add initial tick label in date series

### DIFF
--- a/build/g-axis.js
+++ b/build/g-axis.js
@@ -32,7 +32,14 @@
                 .tickSize(tickSize)
                 .ticks(getTicks(interval))
                 .tickFormat(tickFormat(interval))
-                .scale(scale)
+                .scale(scale);
+
+            const newTicks = scale.ticks(getTicks(interval));
+            newTicks.unshift(scale.domain()[0]);
+            if (interval === 'lustrum' || interval === 'decade' || interval === 'jubilee' || interval === 'century') {
+                newTicks.push(d3.timeYear(scale.domain()[1]));
+            }
+            xAxis.tickValues(newTicks);
 
             const xMinor = d3.axisBottom()
                 .tickSize(minorTickSize)

--- a/src/xDate.js
+++ b/src/xDate.js
@@ -28,7 +28,14 @@ export default function () {
             .tickSize(tickSize)
             .ticks(getTicks(interval))
             .tickFormat(tickFormat(interval))
-            .scale(scale)
+            .scale(scale);
+
+        const newTicks = scale.ticks(getTicks(interval));
+        newTicks.unshift(scale.domain()[0]);
+        if (interval === 'lustrum' || interval === 'decade' || interval === 'jubilee' || interval === 'century') {
+            newTicks.push(d3.timeYear(scale.domain()[1]));
+        }
+        xAxis.tickValues(newTicks);
 
         const xMinor = d3.axisBottom()
             .tickSize(minorTickSize)


### PR DESCRIPTION
Adds an initial tick on the major axis and final tick for intervals of lustrum and above.
Copies the major tick array to a new constant then unshifts the domain[0] values into it forcing a new tick outside the interval filtering