### PR TITLE
Lints all axes, fixes default export of xDate

### DIFF
--- a/src/xDate.js
+++ b/src/xDate.js
@@ -1,9 +1,11 @@
+import * as d3 from 'd3';
 
-function xaxisDate() {
+export default function xaxisDate() {
     let banding;
     const mindate = new Date(1970, 1, 1);
     const maxdate = new Date(2017, 6, 1);
-    let scale = d3.scaleTime()
+    let scale = d3
+        .scaleTime()
         .domain([mindate, maxdate])
         .range([0, 220]);
     let frameName;
@@ -31,7 +33,8 @@ function xaxisDate() {
             if (intraday) {
                 const newDomain = scale.domain();
                 const newRange = scale.range();
-                scale = d3.scalePoint()
+                scale = d3
+                    .scalePoint()
                     .domain(newDomain)
                     .range(newRange);
                 return {
@@ -51,12 +54,18 @@ function xaxisDate() {
                 .tickSize(tickSize)
                 .tickFormat(tickFormat(interval))
                 .scale(scale);
-            xAxis.tickValues(scale.domain().filter((d, i) => {
-                let checkDate;
-                if (i === 0) { return d.getDay(); }
-                if (i > 0) { checkDate = new Date(scale.domain()[i - 1]); }
-                return (d.getDay() !== checkDate.getDay());
-            }));
+            xAxis.tickValues(
+                scale.domain().filter((d, i) => {
+                    let checkDate;
+                    if (i === 0) {
+                        return d.getDay();
+                    }
+                    if (i > 0) {
+                        checkDate = new Date(scale.domain()[i - 1]);
+                    }
+                    return d.getDay() !== checkDate.getDay();
+                }),
+            );
         } else {
             xAxis
                 .tickSize(tickSize)
@@ -64,15 +73,22 @@ function xaxisDate() {
                 .tickFormat(tickFormat(interval))
                 .scale(scale);
             let newTicks = scale.ticks(getTicks(interval));
-            const dayCheck = (scale.domain()[0]).getDate();
+            const dayCheck = scale.domain()[0].getDate();
             const monthCheck = scale.domain()[0].getMonth();
             if (dayCheck !== 1 && monthCheck !== 0) {
                 newTicks.unshift(scale.domain()[0]);
             }
-            if (interval === 'lustrum' || interval === 'decade' || interval === 'jubilee' || interval === 'century') {
+            if (
+                interval === 'lustrum' ||
+                interval === 'decade' ||
+                interval === 'jubilee' ||
+                interval === 'century'
+            ) {
                 newTicks.push(d3.timeYear(scale.domain()[1]));
             }
-            if (endTicks) { newTicks = scale.domain(); }
+            if (endTicks) {
+                newTicks = scale.domain();
+            }
             xAxis.tickValues(newTicks);
         }
 
@@ -98,16 +114,16 @@ function xaxisDate() {
             xAxis.tickFormat(customFormat);
         }
 
-        let bandHolder = parent
-            .append('g')
-            .attr('class', 'highlights');
+        const bandHolder = parent.append('g').attr('class', 'highlights');
 
-        xLabel = parent.append('g')
+        xLabel = parent
+            .append('g')
             .attr('class', 'axis xAxis axis baseline')
             .call(xAxis);
 
         if (minorAxis) {
-            xLabelMinor = parent.append('g')
+            xLabelMinor = parent
+                .append('g')
                 .attr('class', () => {
                     if (plotHeight === tickSize) {
                         return 'axis xAxis';
@@ -118,94 +134,94 @@ function xaxisDate() {
         }
 
         if (frameName) {
-            xLabel.selectAll('.axis.xAxis text')
-            .attr('id', `${frameName}xLabel`);
-            xLabel.selectAll('.axis.xAxis line')
-            .attr('id', `${frameName}xTick`);
-            if (minorAxis) {
-                xLabelMinor.selectAll('.axis.xAxis line')
+            xLabel
+                .selectAll('.axis.xAxis text')
+                .attr('id', `${frameName}xLabel`);
+            xLabel
+                .selectAll('.axis.xAxis line')
                 .attr('id', `${frameName}xTick`);
+            if (minorAxis) {
+                xLabelMinor
+                    .selectAll('.axis.xAxis line')
+                    .attr('id', `${frameName}xTick`);
             }
         }
-        
+
         if (label) {
             const defaultLabel = {
                 tag: label.tag,
-                hori: (label.hori || 'middle'),
-                vert: (label.vert || 'bottom'),
-                anchor: (label.anchor || 'middle'),
-                rotate: (label.rotate || 0),
+                hori: label.hori || 'middle',
+                vert: label.vert || 'bottom',
+                anchor: label.anchor || 'middle',
+                rotate: label.rotate || 0,
             };
 
-            const axisLabel = parent.append('g')
-                .attr('class', 'axis xAxis');
+            const axisLabel = parent.append('g').attr('class', 'axis xAxis');
+            const calcOffset = () => {
+                if (tickSize > 0 && tickSize < rem) {
+                    return tickSize + (rem * 0.8); // prettier-ignore
+                }
+                return rem * 0.9;
+            };
+            const getVertical = (axisAlign, vertAlign) =>
+                ({
+                    toptop: 0 - rem,
+                    topmiddle: 0,
+                    topbottom: 0 + rem,
+                    bottomtop: plotHeight,
+                    bottommiddle: plotHeight + calcOffset(),
+                    bottombottom: plotHeight + calcOffset() + (rem * 1.1), // prettier-ignore
+                }[axisAlign + vertAlign]);
 
-            axisLabel.append('text')
-                .attr('y', getVerticle(align, defaultLabel.vert))
+            const getHorizontal = hori =>
+                ({
+                    left: plotWidth - plotWidth,
+                    middle: plotWidth / 2,
+                    right: plotWidth,
+                }[hori]);
+
+            axisLabel
+                .append('text')
+                .attr('y', getVertical(align, defaultLabel.vert))
                 .attr('x', getHorizontal(defaultLabel.hori))
                 .text(defaultLabel.tag);
 
             const text = axisLabel.selectAll('text');
-            const width = (text.node().getBBox().width) / 2;
-            const height = (text.node().getBBox().height) / 2;
+            const width = text.node().getBBox().width / 2;
+            const height = text.node().getBBox().height / 2;
             const textX = text.node().getBBox().x + width;
             const textY = text.node().getBBox().y + height;
-            text.attr('transform', 'rotate(' + (defaultLabel.rotate) + ', ' + textX + ', ' + textY + ')')
-                .style('text-anchor', defaultLabel.anchor);
-
-            function getVerticle(axisAlign, vertAlign) {
-                return {
-                    toptop: 0 - (rem),
-                    topmiddle: 0,
-                    topbottom: 0 + (rem),
-                    bottomtop: plotHeight,
-                    bottommiddle: plotHeight + calcOffset(),
-                    bottombottom: plotHeight + calcOffset()+ (rem * 1.1),
-                }[axisAlign + vertAlign];
-            }
-            function calcOffset() {
-                if (tickSize > 0 && tickSize < rem) {
-                    return tickSize + (rem * 0.8);
-                }
-                return (rem * 0.9);
-            }
-
-            function getHorizontal(hori) {
-                return {
-                    left: plotWidth - plotWidth,
-                    middle: plotWidth / 2,
-                    right: plotWidth,
-                }[hori];
-            }
+            text.attr(
+                'transform',
+                `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`,
+            ).style('text-anchor', defaultLabel.anchor);
         }
         if (banding) {
-            let bands = xAxis.tickValues()
-            bands = bands.map((d,i) => {
-                return{
+            let bands = xAxis.tickValues();
+            const getBandWidth = (index) => {
+                if (index === bands.length - 1) {
+                    return plotWidth - scale(bands[index]);
+                }
+                return scale(bands[index + 1]) - scale(bands[index]);
+            };
+            bands = bands
+                .map((d, i) => ({
                     date: d,
-                    width: getBandWidth(i)
-                }
-            })
-            .filter((d, i) => {
-                return i % 2 === 0;
-            })
+                    width: getBandWidth(i),
+                }))
+                .filter((d, i) => i % 2 === 0);
 
-        function getBandWidth(index) {
-                if (index === bands.length-1) {
-                    return plotWidth - scale(bands[index])
-                }
-                return scale(bands[index+1]) - scale(bands[index])
-            }
-            console.log('bands', bands)
-            
-            bandHolder.selectAll('rect')
+            console.log('bands', bands);
+
+            bandHolder
+                .selectAll('rect')
                 .data(bands)
                 .enter()
                 .append('rect')
                 .attr('y', 0)
                 .attr('height', plotHeight)
                 .attr('x', d => scale(d.date))
-                .attr('width', d => d.width)
+                .attr('width', d => d.width);
         }
 
         xLabel.selectAll('.domain').remove();
@@ -314,7 +330,7 @@ function xaxisDate() {
         }
 
         function getDaily(d, i) {
-            const last = scale.domain().length-1
+            const last = scale.domain().length - 1;
             if (i === 0) {
                 return `${formatDay(d)} ${formatMonth(d)}`;
             }
@@ -327,7 +343,7 @@ function xaxisDate() {
             if (i === last) {
                 return formatDay(d);
             }
-            return ''
+            return '';
         }
 
         function getWeek(d) {
@@ -365,13 +381,13 @@ function xaxisDate() {
         }
 
         function checkCentury(d, i) {
-            if (fullYear || (+formatFullYear(d) % 100 === 0) || (i === 0)) {
+            if (fullYear || +formatFullYear(d) % 100 === 0 || i === 0) {
                 return formatFullYear(d);
             }
             return formatYear(d);
         }
         function getFiscal(d, i) {
-            if (fullYear || (+formatFullYear(d) % 100 === 0) || (i === 0)) {
+            if (fullYear || +formatFullYear(d) % 100 === 0 || i === 0) {
                 return `${formatFullYear(d)}/${Number(formatYear(d)) + 1}`;
             }
             return `${formatYear(d)}/${Number(formatYear(d)) + 1}`;

--- a/src/xLinear.js
+++ b/src/xLinear.js
@@ -2,7 +2,8 @@ import * as d3 from 'd3';
 
 export default function () {
     let banding;
-    let scale = d3.scaleLinear()
+    let scale = d3
+        .scaleLinear()
         .domain([0, 100])
         .range([0, 220]);
     let tickSize = 50;
@@ -38,19 +39,32 @@ export default function () {
             scale.range(newRange);
         }
         if (logScale) {
-            const newScale = d3.scaleLog()
-            .domain(scale.domain())
-            .range(scale.range());
+            const newScale = d3
+                .scaleLog()
+                .domain(scale.domain())
+                .range(scale.range());
             scale = newScale;
         }
 
         let deciFormat;
-        if (span >= 0.5) { deciFormat = d3.format('.1f'); }
-        if (span < 0.5) { deciFormat = d3.format('.2f'); }
-        if (span <= 0.011) { deciFormat = d3.format('.3f'); }
-        if (span < 0.0011) { deciFormat = d3.format('.4f'); }
-        if (span < 0.00011) { deciFormat = d3.format('.5f'); }
-        if (span < 0.000011) { deciFormat = d3.format('.6f'); }
+        if (span >= 0.5) {
+            deciFormat = d3.format('.1f');
+        }
+        if (span < 0.5) {
+            deciFormat = d3.format('.2f');
+        }
+        if (span <= 0.011) {
+            deciFormat = d3.format('.3f');
+        }
+        if (span < 0.0011) {
+            deciFormat = d3.format('.4f');
+        }
+        if (span < 0.00011) {
+            deciFormat = d3.format('.5f');
+        }
+        if (span < 0.000011) {
+            deciFormat = d3.format('.6f');
+        }
         const numberFormat = d3.format(',');
 
         const xAxis = getAxis(align)
@@ -61,9 +75,15 @@ export default function () {
 
         function formatNumber(d) {
             const checkDecimal = Number.isInteger(d / divisor);
-            if (checkDecimal === false) { deciCheck = true; }
-            if (d / divisor === 0) { return numberFormat(d / divisor); }
-            if (logScale) { return numberFormat(d / divisor); }
+            if (checkDecimal === false) {
+                deciCheck = true;
+            }
+            if (d / divisor === 0) {
+                return numberFormat(d / divisor);
+            }
+            if (logScale) {
+                return numberFormat(d / divisor);
+            }
             if (deciCheck) {
                 return deciFormat(d / divisor);
             }
@@ -78,72 +98,77 @@ export default function () {
             xAxis.tickFormat(customFormat);
         }
 
-        const bandHolder = parent
-            .append('g')
-            .attr('class', 'highlights');
+        const bandHolder = parent.append('g').attr('class', 'highlights');
 
-        xLabel = parent.append('g')
+        xLabel = parent
+            .append('g')
             .attr('class', 'axis xAxis')
             .call(xAxis);
 
-        xLabel.selectAll('.tick')
+        xLabel
+            .selectAll('.tick')
             .filter(d => d === 0 || d === xAxisHighlight)
             .classed('baseline', true);
 
         if (frameName) {
-            xLabel.selectAll('.axis.xAxis text')
-            .attr('id', `${frameName}xLabel`);
-            xLabel.selectAll('.axis.xAxis line')
-            .attr('id', `${frameName}xTick`);
+            xLabel
+                .selectAll('.axis.xAxis text')
+                .attr('id', `${frameName}xLabel`);
+            xLabel
+                .selectAll('.axis.xAxis line')
+                .attr('id', `${frameName}xTick`);
         }
 
         if (label) {
             const defaultLabel = {
                 tag: label.tag,
-                hori: (label.hori || 'middle'),
-                vert: (label.vert || 'bottom'),
-                anchor: (label.anchor || 'middle'),
-                rotate: (label.rotate || 0),
+                hori: label.hori || 'middle',
+                vert: label.vert || 'bottom',
+                anchor: label.anchor || 'middle',
+                rotate: label.rotate || 0,
             };
 
-            const axisLabel = parent.append('g')
-                .attr('class', 'axis xAxis');
-
+            const axisLabel = parent.append('g').attr('class', 'axis xAxis');
 
             const calcOffset = () => {
                 if (tickSize > 0 && tickSize < rem) {
-                    return tickSize + (rem * 0.8);
+                    return tickSize + (rem * 0.8); // prettier-ignore
                 }
-                return (rem * 0.9);
+                return (rem * 0.9); // prettier-ignore
             };
 
-            const getVerticle = (axisAlign, vertAlign) => ({
-                toptop: 0 - (rem),
-                topmiddle: 0,
-                topbottom: 0 + (rem),
-                bottomtop: plotHeight,
-                bottommiddle: plotHeight + calcOffset(),
-                bottombottom: plotHeight + calcOffset() + (rem * 1.1),
-            }[axisAlign + vertAlign]);
+            const getVertical = (axisAlign, vertAlign) =>
+                ({
+                    toptop: 0 - rem,
+                    topmiddle: 0,
+                    topbottom: 0 + rem,
+                    bottomtop: plotHeight,
+                    bottommiddle: plotHeight + calcOffset(),
+                    bottombottom: plotHeight + calcOffset() + (rem * 1.1), // prettier-ignore
+                }[axisAlign + vertAlign]);
 
-            const getHorizontal = hori => ({
-                left: plotWidth - plotWidth,
-                middle: plotWidth / 2,
-                right: plotWidth,
-            }[hori]);
+            const getHorizontal = hori =>
+                ({
+                    left: plotWidth - plotWidth,
+                    middle: plotWidth / 2,
+                    right: plotWidth,
+                }[hori]);
 
-            axisLabel.append('text')
-                .attr('y', getVerticle(align, defaultLabel.vert))
+            axisLabel
+                .append('text')
+                .attr('y', getVertical(align, defaultLabel.vert))
                 .attr('x', getHorizontal(defaultLabel.hori))
                 .text(defaultLabel.tag);
 
             const text = axisLabel.selectAll('text');
-            const width = (text.node().getBBox().width) / 2;
-            const height = (text.node().getBBox().height) / 2;
+            const width = text.node().getBBox().width / 2;
+            const height = text.node().getBBox().height / 2;
             const textX = text.node().getBBox().x + width;
             const textY = text.node().getBBox().y + height;
-            text.attr('transform', `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`)
-                .style('text-anchor', defaultLabel.anchor);
+            text.attr(
+                'transform',
+                `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`,
+            ).style('text-anchor', defaultLabel.anchor);
         }
 
         if (banding) {
@@ -154,14 +179,18 @@ export default function () {
                 return scale(bands[index + 1]) - scale(bands[index]);
             };
 
-            const bands = (tickValues ? xAxis.tickValues() : scale.ticks(numTicks))
+            const bands = (tickValues
+                ? xAxis.tickValues()
+                : scale.ticks(numTicks)
+            )
                 .map((d, i, a) => ({
                     pos: d,
                     width: getBandWidth(i, a),
                 }))
                 .filter((d, i) => i % 2 === 0);
 
-            bandHolder.selectAll('rect')
+            bandHolder
+                .selectAll('rect')
                 .data(bands)
                 .enter()
                 .append('rect')
@@ -171,7 +200,8 @@ export default function () {
                 .attr('width', d => d.width);
         }
 
-        xLabel.selectAll('.tick')
+        xLabel
+            .selectAll('.tick')
             .filter(d => d === 0 || d === xAxisHighlight)
             .classed('baseline', true);
 

--- a/src/xOrdinal.js
+++ b/src/xOrdinal.js
@@ -3,7 +3,8 @@ import * as d3 from 'd3';
 export default function xAxisOrdinal() {
     let banding;
     let align = 'bottom';
-    let scale = d3.scaleBand()
+    let scale = d3
+        .scaleBand()
         .domain(['Oranges', 'Lemons', 'Apples', 'Pears'])
         .rangeRound([0, 220])
         .paddingInner(0.1)
@@ -35,79 +36,85 @@ export default function xAxisOrdinal() {
             scale.paddingInner(0.2);
         }
 
-        const bandHolder = parent
-            .append('g')
-            .attr('class', 'highlights');
+        const bandHolder = parent.append('g').attr('class', 'highlights');
 
-        xLabel = parent.append('g')
+        xLabel = parent
+            .append('g')
             .attr('class', 'axis xAxis')
             .call(xAxis);
 
         if (frameName) {
-            xLabel.selectAll('.axis.xAxis text')
-            .attr('id', `${frameName}xLabel`);
-            xLabel.selectAll('.axis.xAxis line')
-            .attr('id', `${frameName}xTick`);
+            xLabel
+                .selectAll('.axis.xAxis text')
+                .attr('id', `${frameName}xLabel`);
+            xLabel
+                .selectAll('.axis.xAxis line')
+                .attr('id', `${frameName}xTick`);
         }
 
         if (label) {
             const calcOffset = () => {
                 if (tickSize > 0 && tickSize < rem) {
-                    return tickSize + (rem * 0.8);
+                    return tickSize + (rem * 0.8); // prettier-ignore
                 }
-                return (rem * 0.9);
+                return (rem * 0.9); // prettier-ignore
             };
 
-            const getVerticle = (axisAlign, vertAlign) => ({
-                toptop: 0 - (rem),
-                topmiddle: 0,
-                topbottom: 0 + (rem),
-                bottomtop: plotHeight,
-                bottommiddle: plotHeight + calcOffset(),
-                bottombottom: plotHeight + calcOffset() + (rem * 1.1),
-            }[axisAlign + vertAlign]);
+            const getVertical = (axisAlign, vertAlign) =>
+                ({
+                    toptop: 0 - rem,
+                    topmiddle: 0,
+                    topbottom: 0 + rem,
+                    bottomtop: plotHeight,
+                    bottommiddle: plotHeight + calcOffset(),
+                    bottombottom: plotHeight + calcOffset() + (rem * 1.1), // prettier-ignore
+                }[axisAlign + vertAlign]);
 
-            const getHorizontal = hori => ({
-                left: plotWidth - plotWidth,
-                middle: plotWidth / 2,
-                right: plotWidth,
-            }[hori]);
+            const getHorizontal = hori =>
+                ({
+                    left: plotWidth - plotWidth,
+                    middle: plotWidth / 2,
+                    right: plotWidth,
+                }[hori]);
 
             const defaultLabel = {
                 tag: label.tag,
-                hori: (label.hori || 'middle'),
-                vert: (label.vert || 'bottom'),
-                anchor: (label.anchor || 'middle'),
-                rotate: (label.rotate || 0),
+                hori: label.hori || 'middle',
+                vert: label.vert || 'bottom',
+                anchor: label.anchor || 'middle',
+                rotate: label.rotate || 0,
             };
 
-            const axisLabel = parent.append('g')
-                .attr('class', 'axis xAxis');
+            const axisLabel = parent.append('g').attr('class', 'axis xAxis');
 
-
-            axisLabel.append('text')
-                .attr('y', getVerticle(align, defaultLabel.vert))
+            axisLabel
+                .append('text')
+                .attr('y', getVertical(align, defaultLabel.vert))
                 .attr('x', getHorizontal(defaultLabel.hori))
                 .text(defaultLabel.tag);
 
             const text = axisLabel.selectAll('text');
-            const width = (text.node().getBBox().width) / 2;
-            const height = (text.node().getBBox().height) / 2;
+            const width = text.node().getBBox().width / 2;
+            const height = text.node().getBBox().height / 2;
             const textX = text.node().getBBox().x + width;
             const textY = text.node().getBBox().y + height;
-            text.attr('transform', `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`)
-                .style('text-anchor', defaultLabel.anchor);
+            text.attr(
+                'transform',
+                `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`,
+            ).style('text-anchor', defaultLabel.anchor);
         }
 
         if (banding) {
-            const bands = scale.domain()
+            const bands = scale
+                .domain()
                 .map(d => ({
                     pos: d,
                 }))
                 .filter((d, i) => i % 2 === 1);
 
-            const yOffset = (scale.step() / 100) * (scale.paddingInner() * 100);
+            const yOffset = (scale.step() / 100) * (scale.paddingInner() * 100); // prettier-ignore
 
+            // prettier-ignore
             bandHolder.selectAll('rect')
                 .data(bands)
                 .enter()

--- a/src/yDate.js
+++ b/src/yDate.js
@@ -4,7 +4,8 @@ export default function () {
     let banding;
     const mindate = new Date(1970, 1, 1);
     const maxdate = new Date(2017, 6, 1);
-    let scale = d3.scaleTime()
+    let scale = d3
+        .scaleTime()
         .domain([mindate, maxdate])
         .range([0, 220]);
     let frameName;
@@ -34,7 +35,8 @@ export default function () {
                 console.log('intraday axis'); // eslint-disable-line
                 const newDomain = scale.domain();
                 const newRange = scale.range();
-                scale = d3.scalePoint()
+                scale = d3
+                    .scalePoint()
                     .domain(newDomain)
                     .range(newRange);
                 return {
@@ -54,12 +56,18 @@ export default function () {
                 .tickSize(tickSize)
                 .tickFormat(tickFormat(interval))
                 .scale(scale);
-            yAxis.tickValues(scale.domain().filter((d, i) => {
-                let checkDate;
-                if (i === 0) { return d.getDay(); }
-                if (i > 0) { checkDate = new Date(scale.domain()[i - 1]); }
-                return (d.getDay() !== checkDate.getDay());
-            }));
+            yAxis.tickValues(
+                scale.domain().filter((d, i) => {
+                    let checkDate;
+                    if (i === 0) {
+                        return d.getDay();
+                    }
+                    if (i > 0) {
+                        checkDate = new Date(scale.domain()[i - 1]);
+                    }
+                    return d.getDay() !== checkDate.getDay();
+                }),
+            );
         } else {
             yAxis
                 .tickSize(tickSize)
@@ -67,15 +75,22 @@ export default function () {
                 .tickFormat(tickFormat(interval))
                 .scale(scale);
             let newTicks = scale.ticks(getTicks(interval));
-            const dayCheck = (scale.domain()[0]).getDate();
+            const dayCheck = scale.domain()[0].getDate();
             const monthCheck = scale.domain()[0].getMonth();
             if (dayCheck !== 1 && monthCheck !== 0) {
                 newTicks.unshift(scale.domain()[0]);
             }
-            if (interval === 'lustrum' || interval === 'decade' || interval === 'jubilee' || interval === 'century') {
+            if (
+                interval === 'lustrum' ||
+                interval === 'decade' ||
+                interval === 'jubilee' ||
+                interval === 'century'
+            ) {
                 newTicks.push(d3.timeYear(scale.domain()[1]));
             }
-            if (endTicks) { newTicks = scale.domain(); }
+            if (endTicks) {
+                newTicks = scale.domain();
+            }
             yAxis.tickValues(newTicks);
         }
 
@@ -101,11 +116,10 @@ export default function () {
             yAxis.tickFormat(customFormat);
         }
 
-        const bandHolder = parent
-            .append('g')
-            .attr('class', 'highlights');
+        const bandHolder = parent.append('g').attr('class', 'highlights');
 
-        yLabel = parent.append('g')
+        yLabel = parent
+            .append('g')
             .attr('class', 'axis yAxis axis baseline')
             .call(yAxis);
 
@@ -117,18 +131,27 @@ export default function () {
         // Use this to amend the tickSIze and re cal the vAxis
         if (tickSize < labelWidth) {
             yLabel.call(yAxis.tickSize);
-        } else { yLabel.call(yAxis.tickSize(tickSize - labelWidth)); }
+        } else {
+            yLabel.call(yAxis.tickSize(tickSize - labelWidth));
+        }
 
         if (align === 'right') {
-            yLabel.selectAll('text')
-            .attr('transform', `translate(${(labelWidth)},0)`)
-            .style('text-anchor', 'end');
-        } else { yLabel.selectAll('text').style('text-anchor', 'end'); }
+            yLabel
+                .selectAll('text')
+                .attr('transform', `translate(${labelWidth},0)`)
+                .style('text-anchor', 'end');
+        } else {
+            yLabel.selectAll('text').style('text-anchor', 'end');
+        }
 
         if (minorAxis) {
-            yLabelMinor = parent.append('g')
+            yLabelMinor = parent
+                .append('g')
                 .attr('class', () => {
-                    const pHeight = d3.select('.chart-plot').node().getBBox().height;
+                    const pHeight = d3
+                        .select('.chart-plot')
+                        .node()
+                        .getBBox().height;
                     if (pHeight === tickSize) {
                         return 'axis yAxis';
                     }
@@ -138,32 +161,35 @@ export default function () {
         }
 
         if (frameName) {
-            yLabel.selectAll('.axis.yAxis text')
-            .attr('id', `${frameName}yLabel`);
-            yLabel.selectAll('.axis.yAxis line')
-            .attr('id', `${frameName}xTick`);
-            if (minorAxis) {
-                yLabelMinor.selectAll('.axis.yAxis line')
+            yLabel
+                .selectAll('.axis.yAxis text')
+                .attr('id', `${frameName}yLabel`);
+            yLabel
+                .selectAll('.axis.yAxis line')
                 .attr('id', `${frameName}xTick`);
+            if (minorAxis) {
+                yLabelMinor
+                    .selectAll('.axis.yAxis line')
+                    .attr('id', `${frameName}xTick`);
             }
         }
         if (label) {
             const defaultLabel = {
                 tag: label.tag,
-                hori: (label.hori || 'left'),
-                vert: (label.vert || 'middle'),
-                anchor: (label.anchor || 'middle'),
-                rotate: (label.rotate || -90),
+                hori: label.hori || 'left',
+                vert: label.vert || 'middle',
+                anchor: label.anchor || 'middle',
+                rotate: label.rotate || -90,
             };
 
-            const axisLabel = parent.append('g')
-                .attr('class', 'axis xAxis');
+            const axisLabel = parent.append('g').attr('class', 'axis xAxis');
 
-            const getVerticle = vert => ({
-                top: plotHeight - plotHeight,
-                middle: plotHeight / 2,
-                bottom: plotHeight,
-            }[vert]);
+            const getVertical = vert =>
+                ({
+                    top: plotHeight - plotHeight,
+                    middle: plotHeight / 2,
+                    bottom: plotHeight,
+                }[vert]);
 
             const calcOffset = () => {
                 if (tickSize > 0 && tickSize < rem) {
@@ -172,6 +198,7 @@ export default function () {
                 return 0;
             };
 
+            // prettier-ignore
             const getHorizontal = (axisAlign, horiAlign) => ({
                 leftleft: 0 - (labelWidth + (rem * 0.6)),
                 leftmiddle: 0 - (labelWidth / 2) - calcOffset(),
@@ -181,8 +208,9 @@ export default function () {
                 rightright: plotWidth + (rem) + calcOffset(),
             }[axisAlign + horiAlign]);
 
-            axisLabel.append('text')
-                .attr('y', getVerticle(defaultLabel.vert))
+            axisLabel
+                .append('text')
+                .attr('y', getVertical(defaultLabel.vert))
                 .attr('x', getHorizontal(align, defaultLabel.hori))
                 .text(defaultLabel.tag);
 
@@ -205,14 +233,16 @@ export default function () {
                 return scale(bands[index + 1]) - scale(bands[index]);
             };
 
-            const bands = yAxis.tickValues()
+            const bands = yAxis
+                .tickValues()
                 .map((d, i, a) => ({
                     date: d,
                     height: getBandWidth(i, a),
                 }))
                 .filter((d, i) => i % 2 === 0);
 
-            bandHolder.selectAll('rect')
+            bandHolder
+                .selectAll('rect')
                 .data(bands)
                 .enter()
                 .append('rect')
@@ -361,13 +391,13 @@ export default function () {
         }
 
         function checkCentury(d, i) {
-            if (fullYear || (+formatFullYear(d) % 100 === 0) || (i === 0)) {
+            if (fullYear || +formatFullYear(d) % 100 === 0 || i === 0) {
                 return formatFullYear(d);
             }
             return formatYear(d);
         }
         function getFiscal(d, i) {
-            if (fullYear || (+formatFullYear(d) % 100 === 0) || (i === 0)) {
+            if (fullYear || +formatFullYear(d) % 100 === 0 || i === 0) {
                 return `${formatFullYear(d)}/${Number(formatYear(d)) + 1}`;
             }
             return `${formatYear(d)}/${Number(formatYear(d)) + 1}`;

--- a/src/yLinear.js
+++ b/src/yLinear.js
@@ -2,7 +2,8 @@ import * as d3 from 'd3';
 
 export default function () {
     let banding;
-    let scale = d3.scaleLinear()
+    let scale = d3
+        .scaleLinear()
         .domain([0, 10000])
         .range([120, 0]);
     let align = 'right';
@@ -28,9 +29,10 @@ export default function () {
         const plotHeight = plotDim[1];
 
         if (logScale) {
-            const newScale = d3.scaleLog()
-            .domain(scale.domain())
-            .range(scale.range());
+            const newScale = d3
+                .scaleLog()
+                .domain(scale.domain())
+                .range(scale.range());
             scale = newScale;
         }
         if (invert) {
@@ -39,12 +41,24 @@ export default function () {
         }
 
         let deciFormat;
-        if (span >= 0.5) { deciFormat = d3.format('.1f'); }
-        if (span < 0.5) { deciFormat = d3.format('.2f'); }
-        if (span <= 0.011) { deciFormat = d3.format('.3f'); }
-        if (span < 0.0011) { deciFormat = d3.format('.4f'); }
-        if (span < 0.00011) { deciFormat = d3.format('.5f'); }
-        if (span < 0.000011) { deciFormat = d3.format('.6f'); }
+        if (span >= 0.5) {
+            deciFormat = d3.format('.1f');
+        }
+        if (span < 0.5) {
+            deciFormat = d3.format('.2f');
+        }
+        if (span <= 0.011) {
+            deciFormat = d3.format('.3f');
+        }
+        if (span < 0.0011) {
+            deciFormat = d3.format('.4f');
+        }
+        if (span < 0.00011) {
+            deciFormat = d3.format('.5f');
+        }
+        if (span < 0.000011) {
+            deciFormat = d3.format('.6f');
+        }
         const numberFormat = d3.format(',');
 
         const yAxis = getAxis(align)
@@ -54,9 +68,15 @@ export default function () {
 
         function formatNumber(d) {
             const checkDecimal = Number.isInteger(d / divisor);
-            if (checkDecimal === false) { deciCheck = true; }
-            if (d / divisor === 0) { return numberFormat(d / divisor); }
-            if (logScale) { return numberFormat(d / divisor); }
+            if (checkDecimal === false) {
+                deciCheck = true;
+            }
+            if (d / divisor === 0) {
+                return numberFormat(d / divisor);
+            }
+            if (logScale) {
+                return numberFormat(d / divisor);
+            }
             if (deciCheck) {
                 return deciFormat(d / divisor);
             }
@@ -71,16 +91,14 @@ export default function () {
             yAxis.tickFormat(customFormat);
         }
 
-        const bandHolder = parent
+        const bandHolder = parent.append('g').attr('class', 'highlights');
+
+        yLabel = parent
             .append('g')
-            .attr('class', 'highlights');
+            .attr('class', 'axis yAxis')
+            .call(yAxis);
 
-        yLabel = parent.append('g')
-          .attr('class', 'axis yAxis')
-          .call(yAxis);
-
-
-    // Calculate width of widest .tick text
+        // Calculate width of widest .tick text
         yLabel.selectAll('.yAxis text').each(function calcTickTextWidth() {
             labelWidth = Math.max(this.getBBox().width, labelWidth);
         });
@@ -88,37 +106,42 @@ export default function () {
         // Use this to amend the tickSIze and re cal the vAxis
         if (tickSize < labelWidth) {
             yLabel.call(yAxis.tickSize(tickSize));
-        } else { yLabel.call(yAxis.tickSize(tickSize - labelWidth)); }
+        } else {
+            yLabel.call(yAxis.tickSize(tickSize - labelWidth));
+        }
 
         if (align === 'right') {
-            yLabel.selectAll('text')
-            .attr('transform', `translate(${(labelWidth)},0)`);
+            yLabel
+                .selectAll('text')
+                .attr('transform', `translate(${labelWidth},0)`);
         }
 
         if (frameName) {
-            yLabel.selectAll('.axis.yAxis text')
-            .attr('id', `${frameName}yLabel`);
-            yLabel.selectAll('.axis.yAxis line')
-            .attr('id', `${frameName}yTick`);
+            yLabel
+                .selectAll('.axis.yAxis text')
+                .attr('id', `${frameName}yLabel`);
+            yLabel
+                .selectAll('.axis.yAxis line')
+                .attr('id', `${frameName}yTick`);
         }
 
         if (label) {
             const defaultLabel = {
                 tag: label.tag,
-                hori: (label.hori || 'left'),
-                vert: (label.vert || 'middle'),
-                anchor: (label.anchor || 'middle'),
-                rotate: (label.rotate || -90),
+                hori: label.hori || 'left',
+                vert: label.vert || 'middle',
+                anchor: label.anchor || 'middle',
+                rotate: label.rotate || -90,
             };
 
-            const axisLabel = parent.append('g')
-                .attr('class', 'axis xAxis');
+            const axisLabel = parent.append('g').attr('class', 'axis xAxis');
 
-            const getVerticle = vert => ({
-                top: plotHeight - plotHeight,
-                middle: plotHeight / 2,
-                bottom: plotHeight,
-            }[vert]);
+            const getVertical = vert =>
+                ({
+                    top: plotHeight - plotHeight,
+                    middle: plotHeight / 2,
+                    bottom: plotHeight,
+                }[vert]);
 
             const calcOffset = () => {
                 if (tickSize > 0 && tickSize < rem) {
@@ -127,6 +150,7 @@ export default function () {
                 return 0;
             };
 
+            // prettier-ignore
             const getHorizontal = (axisAlign, horiAlign) => ({
                 leftleft: 0 - (labelWidth + (rem * 0.6)),
                 leftmiddle: 0 - (labelWidth / 2) - calcOffset(),
@@ -136,18 +160,21 @@ export default function () {
                 rightright: plotWidth + (rem) + calcOffset(),
             }[axisAlign + horiAlign]);
 
-            axisLabel.append('text')
-                .attr('y', getVerticle(defaultLabel.vert))
+            axisLabel
+                .append('text')
+                .attr('y', getVertical(defaultLabel.vert))
                 .attr('x', getHorizontal(align, defaultLabel.hori))
                 .text(defaultLabel.tag);
 
             const text = axisLabel.selectAll('text');
-            const width = (text.node().getBBox().width) / 2;
-            const height = (text.node().getBBox().height) / 2;
+            const width = text.node().getBBox().width / 2;
+            const height = text.node().getBBox().height / 2;
             const textX = text.node().getBBox().x + width;
             const textY = text.node().getBBox().y + height;
-            text.attr('transform', `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`)
-                .style('text-anchor', defaultLabel.anchor);
+            text.attr(
+                'transform',
+                `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`,
+            ).style('text-anchor', defaultLabel.anchor);
         }
 
         if (banding) {
@@ -158,14 +185,18 @@ export default function () {
                 return scale(bands[index - 1]) - scale(bands[index]);
             };
 
-            const bands = (tickValues ? yAxis.tickValues() : scale.ticks(numTicks))
+            const bands = (tickValues
+                ? yAxis.tickValues()
+                : scale.ticks(numTicks)
+            )
                 .map((d, i, a) => ({
                     pos: d,
                     height: getBandWidth(i, a),
                 }))
                 .filter((d, i) => i % 2 === 0);
 
-            bandHolder.selectAll('rect')
+            bandHolder
+                .selectAll('rect')
                 .data(bands)
                 .enter()
                 .append('rect')
@@ -175,7 +206,8 @@ export default function () {
                 .attr('height', d => d.height);
         }
 
-        yLabel.selectAll('.tick')
+        yLabel
+            .selectAll('.tick')
             .filter(d => d === 0 || d === yAxisHighlight)
             .classed('baseline', true);
 

--- a/src/yOrdinal.js
+++ b/src/yOrdinal.js
@@ -3,7 +3,8 @@ import * as d3 from 'd3';
 export default function () {
     let banding;
     let align = 'left';
-    let scale = d3.scaleBand()
+    let scale = d3
+        .scaleBand()
         .domain(['Oranges', 'Lemons', 'Apples', 'Pears'])
         .rangeRound([0, 220])
         .paddingInner(0.1)
@@ -45,11 +46,10 @@ export default function () {
             scale.paddingInner(0.2);
         }
 
-        const bandHolder = parent
-            .append('g')
-            .attr('class', 'highlights');
+        const bandHolder = parent.append('g').attr('class', 'highlights');
 
-        yLabel = parent.append('g')
+        yLabel = parent
+            .append('g')
             .attr('class', 'axis yAxis')
             .call(yAxis);
 
@@ -59,29 +59,31 @@ export default function () {
         });
 
         if (frameName) {
-            yLabel.selectAll('.axis.yAxis text')
-            .attr('id', `${frameName}yLabel`);
-            yLabel.selectAll('.axis.xAxis line')
-            .attr('id', `${frameName}yTick`);
+            yLabel
+                .selectAll('.axis.yAxis text')
+                .attr('id', `${frameName}yLabel`);
+            yLabel
+                .selectAll('.axis.xAxis line')
+                .attr('id', `${frameName}yTick`);
         }
 
         if (label) {
             const defaultLabel = {
                 tag: label.tag,
-                hori: (label.hori || 'left'),
-                vert: (label.vert || 'middle'),
-                anchor: (label.anchor || 'middle'),
-                rotate: (label.rotate || -90),
+                hori: label.hori || 'left',
+                vert: label.vert || 'middle',
+                anchor: label.anchor || 'middle',
+                rotate: label.rotate || -90,
             };
 
-            const axisLabel = parent.append('g')
-                .attr('class', 'axis xAxis');
+            const axisLabel = parent.append('g').attr('class', 'axis xAxis');
 
-            const getVerticle = vert => ({
-                top: plotHeight - plotHeight,
-                middle: plotHeight / 2,
-                bottom: plotHeight,
-            }[vert]);
+            const getVertical = vert =>
+                ({
+                    top: plotHeight - plotHeight,
+                    middle: plotHeight / 2,
+                    bottom: plotHeight,
+                }[vert]);
 
             const calcOffset = () => {
                 if (tickSize > 0 && tickSize < rem) {
@@ -90,6 +92,7 @@ export default function () {
                 return 0;
             };
 
+            // prettier-ignore
             const getHorizontal = (axisAlign, horiAlign) => ({
                 leftleft: 0 - (labelWidth + (rem * 0.6)),
                 leftmiddle: 0 - (labelWidth / 2) - calcOffset(),
@@ -99,29 +102,34 @@ export default function () {
                 rightright: plotWidth + (rem) + calcOffset(),
             }[axisAlign + horiAlign]);
 
-            axisLabel.append('text')
-                .attr('y', getVerticle(defaultLabel.vert))
+            axisLabel
+                .append('text')
+                .attr('y', getVertical(defaultLabel.vert))
                 .attr('x', getHorizontal(align, defaultLabel.hori))
                 .text(defaultLabel.tag);
 
             const text = axisLabel.selectAll('text');
-            const width = (text.node().getBBox().width) / 2;
-            const height = (text.node().getBBox().height) / 2;
+            const width = text.node().getBBox().width / 2;
+            const height = text.node().getBBox().height / 2;
             const textX = text.node().getBBox().x + width;
             const textY = text.node().getBBox().y + height;
-            text.attr('transform', `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`)
-                .style('text-anchor', defaultLabel.anchor);
+            text.attr(
+                'transform',
+                `rotate(${defaultLabel.rotate}, ${textX}, ${textY})`,
+            ).style('text-anchor', defaultLabel.anchor);
         }
 
         if (banding) {
-            const bands = scale.domain()
+            const bands = scale
+                .domain()
                 .map(d => ({
                     pos: d,
                 }))
                 .filter((d, i) => i % 2 === 0);
 
-            const yOffset = (scale.step() / 100) * (scale.paddingInner() * 100);
+            const yOffset = (scale.step() / 100) * (scale.paddingInner() * 100); // prettier-ignore
 
+            // prettier-ignore
             bandHolder.selectAll('rect')
                 .data(bands)
                 .enter()


### PR DESCRIPTION
This does a few things:
- Lints all the files
- Fixes the default export/d3 import of xDate
- Adds `// prettier-ignore` lines here and there to prevent prettier from breaking the `no-mixed-operands` eslint rule
- Renames "getVerticle" to "getVertical"